### PR TITLE
ZRR-94 Chore: 배포시 도커 컨테이너 타임존 Asia/Seoul로 설정하도록 backend-cd.yml 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -71,4 +71,4 @@ jobs:
             docker stop server
             docker rm server
             docker pull moveuk/zziririt
-            docker run -d --rm --name server -v ~/app/logs:/home/logs -p 8080:8080 moveuk/zziririt
+            docker run -d --rm --name server -v ~/app/logs:/home/logs -p 8080:8080 -e TZ=Asia/Seoul moveuk/zziririt


### PR DESCRIPTION
## 연관 티켓
Closes #97

### 상세 내용

backend-cd.yml 파일에서 docker container 실행시 `-e TZ=Asia/Seoul` 설정을 추가함.

수정 전
```
docker run -d --rm --name server -v ~/app/logs:/home/logs -p 8080:8080 moveuk/zziririt
```

수정 후
```
docker run -d --rm --name server -v ~/app/logs:/home/logs -p 8080:8080 -e TZ=Asia/Seoul moveuk/zziririt
```