### PR TITLE
ZRR-97 Feat: Board Category 삭제 후 재개발

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/controller/BoardController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/controller/BoardController.kt
@@ -1,11 +1,9 @@
 package kr.zziririt.zziririt.api.board.controller
 
 import jakarta.validation.Valid
-import kr.zziririt.zziririt.api.board.dto.request.BoardRequest
-import kr.zziririt.zziririt.api.board.dto.request.StreamerBoardApplicationRequest
-import kr.zziririt.zziririt.api.board.dto.request.StreamerBoardRequest
-import kr.zziririt.zziririt.api.board.dto.request.SubscribeBoardRequest
+import kr.zziririt.zziririt.api.board.dto.request.*
 import kr.zziririt.zziririt.api.board.service.BoardService
+import kr.zziririt.zziririt.api.board.service.CategoryService
 import kr.zziririt.zziririt.api.dto.CommonResponse
 import kr.zziririt.zziririt.global.responseEntity
 import kr.zziririt.zziririt.infra.security.UserPrincipal
@@ -21,7 +19,8 @@ import org.springframework.web.multipart.MultipartFile
 @RestController
 @RequestMapping("/api/v1/boards")
 class BoardController(
-    private val boardService: BoardService
+    private val boardService: BoardService,
+    private val categoryService: CategoryService
 ) {
     @PostMapping("/apply")
     fun createStreamerApply(
@@ -60,17 +59,6 @@ class BoardController(
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<CommonResponse<Nothing>> {
         boardService.createStreamerBoard(streamerBoardRequest, userPrincipal)
-        return responseEntity(HttpStatus.CREATED)
-    }
-
-    @PostMapping("/{boardId}")
-    @PreAuthorize("hasRole('ADMIN')")
-    fun createChildBoard(
-        @PathVariable boardId: Long,
-        @Valid @RequestBody boardRequest: BoardRequest,
-        @AuthenticationPrincipal userPrincipal: UserPrincipal
-    ): ResponseEntity<CommonResponse<Nothing>> {
-        boardService.createChildBoard(boardId, boardRequest, userPrincipal)
         return responseEntity(HttpStatus.CREATED)
     }
 
@@ -127,6 +115,28 @@ class BoardController(
     @GetMapping("/streamer")
     fun getStreamers() = responseEntity(HttpStatus.OK) { boardService.getStreamers() }
 
-    @GetMapping("/{boardId}/child")
-    fun getChildBoards(@PathVariable boardId: Long) = responseEntity(HttpStatus.OK) { boardService.getChildBoards(boardId) }
+    @GetMapping("/categories/{categoryId}")
+    fun getCategoryById(
+        @PathVariable categoryId: Long
+    ) = responseEntity(HttpStatus.OK) { categoryService.getCategoryById(categoryId) }
+
+    @GetMapping("/categories")
+    fun getAllCategories() = responseEntity(HttpStatus.OK) { categoryService.getAllCategories() }
+
+    @PostMapping("/{boardId}")
+    fun addCategoryToBoard(
+        @PathVariable boardId:Long,
+        @RequestBody request: CreateCategoryRequest
+    ) = responseEntity(HttpStatus.OK) { boardService.addCategoryToBoard(boardId, request) }
+
+    @GetMapping(("/{boardId}"))
+    fun getCategoriesByBoardId(
+        @PathVariable boardId: Long
+    ) = responseEntity(HttpStatus.OK) { boardService.getCategoriesByBoardId(boardId) }
+
+    @PutMapping("/categories/{categoryId}")
+    fun updateCategoryName(
+        @PathVariable categoryId: Long,
+        @RequestBody request: UpdateCategoryNameRequest
+    ) = responseEntity(HttpStatus.OK) { categoryService.updateCategoryById(categoryId, request)}
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/BoardCategoryResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/BoardCategoryResponse.kt
@@ -1,0 +1,19 @@
+package kr.zziririt.zziririt.api.board.dto.request
+
+import kr.zziririt.zziririt.domain.board.model.BoardCategoryEntity
+import kr.zziririt.zziririt.domain.board.model.CategoryEntity
+
+data class BoardCategoryResponse(
+    val boardId: Long,
+    val categoryId: Long,
+    val categoryName: String,
+) {
+    companion object {
+        fun from(bc: BoardCategoryEntity): BoardCategoryResponse =
+            BoardCategoryResponse(
+                boardId = bc.board.id!!,
+                categoryId = bc.category.id,
+                categoryName = bc.category.categoryName
+            )
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/BoardRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/BoardRequest.kt
@@ -13,10 +13,9 @@ data class BoardRequest (
     @field:NotBlank
     val boardUrl: String,
 ) {
-    fun to(socialMemberEntity: SocialMemberEntity, parent: BoardEntity?) = BoardEntity(
+    fun to(socialMemberEntity: SocialMemberEntity) = BoardEntity(
         boardName = boardName,
         socialMember = socialMemberEntity,
-        parent = parent,
         boardUrl = boardUrl.lowercase(),
         boardType = BoardType.ZZIRIRIT_BOARD
     )

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/CategoryResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/CategoryResponse.kt
@@ -1,0 +1,15 @@
+package kr.zziririt.zziririt.api.board.dto.request
+
+import kr.zziririt.zziririt.domain.board.model.CategoryEntity
+
+data class CategoryResponse(
+    val categoryName: String,
+    val categoryId: Long,
+) {
+    companion object{
+        fun from(category: CategoryEntity) : CategoryResponse = CategoryResponse (
+            categoryName = category.categoryName,
+            categoryId = category.id
+        )
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/CreateCategoryRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/CreateCategoryRequest.kt
@@ -1,0 +1,11 @@
+package kr.zziririt.zziririt.api.board.dto.request
+
+import kr.zziririt.zziririt.domain.board.model.CategoryEntity
+
+data class CreateCategoryRequest(
+    val categoryName: String
+) {
+    fun toEntity() : CategoryEntity = CategoryEntity(
+        categoryName = categoryName
+    )
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/UpdateCategoryNameRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/dto/request/UpdateCategoryNameRequest.kt
@@ -1,0 +1,5 @@
+package kr.zziririt.zziririt.api.board.dto.request
+
+data class UpdateCategoryNameRequest(
+    val newUpdateCategoryName: String
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/service/BoardService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/service/BoardService.kt
@@ -178,13 +178,13 @@ class BoardService(
         boardCategoryRepository.save(boardCategory)
     }
 
-    fun getCategoriesByBoardId(boardId: Long): List<CategoryEntity> {
+    fun getCategoriesByBoardId(boardId: Long): List<BoardCategoryResponse> {
         val board = boardRepository.findByIdOrNull(boardId)
             ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
 
         val boardCategories = boardCategoryRepository.findByBoardId(board.id!!)
 
-        return boardCategories.map { it.category }
+        return boardCategories.map { BoardCategoryResponse.from(it) }
     }
 
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/service/BoardService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/service/BoardService.kt
@@ -77,14 +77,8 @@ class BoardService(
     fun createBoard(boardRequest: BoardRequest, userPrincipal: UserPrincipal) {
         val findMember = socialMemberRepository.findByIdOrNull(userPrincipal.memberId)
             ?: throw RestApiException(ErrorCode.MODEL_NOT_FOUND)
-        val board = boardRepository.save(boardRequest.to(socialMemberEntity = findMember))
 
-        val categoryNames = listOf("공지 사항", "자유 게시판")
-        val categories = categoryNames.map { CategoryEntity(it) }
-        categories.forEach {
-            categoryRepository.save(it)
-            boardCategoryRepository.save(BoardCategoryEntity(board, it))
-        }
+        boardRepository.save(boardRequest.to(socialMemberEntity = findMember))
     }
 
     @Transactional
@@ -158,8 +152,14 @@ class BoardService(
         val boardOwner = socialMemberRepository.findByIdOrNull(streamerBoardRequest.boardOwnerId)
             ?: throw RestApiException(ErrorCode.MODEL_NOT_FOUND)
 
-        boardRepository.save(streamerBoardRequest.to(boardOwner))
+        val board = boardRepository.save(streamerBoardRequest.to(boardOwner))
 
+        val categoryNames = listOf("공지 사항", "잡담 게시판")
+        val categories = categoryNames.map { CategoryEntity(it) }
+        categories.forEach {
+            categoryRepository.save(it)
+            boardCategoryRepository.save(BoardCategoryEntity(board, it))
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/service/CategoryService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/service/CategoryService.kt
@@ -1,0 +1,35 @@
+package kr.zziririt.zziririt.api.board.service
+
+import kr.zziririt.zziririt.api.board.dto.request.UpdateCategoryNameRequest
+import kr.zziririt.zziririt.domain.board.model.CategoryEntity
+import kr.zziririt.zziririt.domain.board.repository.CategoryRepository
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.ModelNotFoundException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CategoryService (
+    private val categoryRepository: CategoryRepository
+){
+    @Transactional
+    fun getCategoryById(categoryId: Long) : CategoryEntity {
+        return categoryRepository.findByIdOrNull(categoryId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+    }
+
+    fun getAllCategories(): List<CategoryEntity> {
+        return categoryRepository.findAll()
+    }
+
+    @Transactional
+    fun updateCategoryById(categoryId: Long, request: UpdateCategoryNameRequest) {
+        val category = categoryRepository.findByIdOrNull(categoryId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        category.updateCategoryName(request.newUpdateCategoryName)
+
+        categoryRepository.save(category)
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/board/service/CategoryService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/board/service/CategoryService.kt
@@ -1,7 +1,7 @@
 package kr.zziririt.zziririt.api.board.service
 
+import kr.zziririt.zziririt.api.board.dto.request.CategoryResponse
 import kr.zziririt.zziririt.api.board.dto.request.UpdateCategoryNameRequest
-import kr.zziririt.zziririt.domain.board.model.CategoryEntity
 import kr.zziririt.zziririt.domain.board.repository.CategoryRepository
 import kr.zziririt.zziririt.global.exception.ErrorCode
 import kr.zziririt.zziririt.global.exception.ModelNotFoundException
@@ -14,13 +14,17 @@ class CategoryService (
     private val categoryRepository: CategoryRepository
 ){
     @Transactional
-    fun getCategoryById(categoryId: Long) : CategoryEntity {
-        return categoryRepository.findByIdOrNull(categoryId)
+    fun getCategoryById(categoryId: Long) : CategoryResponse {
+        val categoryCheck = categoryRepository.findByIdOrNull(categoryId)
             ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        return CategoryResponse.from(categoryCheck)
     }
 
-    fun getAllCategories(): List<CategoryEntity> {
-        return categoryRepository.findAll()
+    fun getAllCategories(): List<CategoryResponse> {
+        val categoryCheck = categoryRepository.findAll()
+
+        return categoryCheck.map { CategoryResponse.from(it) }
     }
 
     @Transactional

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/model/BoardCategoryEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/model/BoardCategoryEntity.kt
@@ -1,0 +1,20 @@
+package kr.zziririt.zziririt.domain.board.model
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "board_category")
+class BoardCategoryEntity (
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    val board: BoardEntity,
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    val category: CategoryEntity
+){
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/model/BoardEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/model/BoardEntity.kt
@@ -12,17 +12,13 @@ import org.hibernate.annotations.SQLRestriction
 @SQLRestriction(value = "is_deleted = false")
 class BoardEntity(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "board_id")
-    val parent: BoardEntity? = null,
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "social_member_id", nullable = false)
     var socialMember: SocialMemberEntity,
 
     @Column(name = "board_name", nullable = false)
     var boardName: String,
 
-    @Column(name = "board_url", nullable = false)
+    @Column(name = "board_url", nullable = false, unique = true)
     var boardUrl: String,
 
     @Enumerated(EnumType.STRING)
@@ -32,6 +28,9 @@ class BoardEntity(
     @Enumerated(EnumType.STRING)
     @Column(name = "board_act_status")
     var boardActStatus: BoardActStatus = BoardActStatus.ACTIVE,
+
+    @OneToMany(mappedBy = "board", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    val boardCategory: MutableList<BoardCategoryEntity> = mutableListOf()
 ) : BaseEntity() {
 
     @Id

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/model/CategoryEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/model/CategoryEntity.kt
@@ -1,0 +1,19 @@
+package kr.zziririt.zziririt.domain.board.model
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "category")
+class CategoryEntity (
+    @Column(name = "category_name")
+    var categoryName: String
+){
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    fun updateCategoryName(newCategoryName: String) {
+        this.categoryName = newCategoryName
+    }
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/BoardCategoryRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/BoardCategoryRepository.kt
@@ -1,0 +1,9 @@
+package kr.zziririt.zziririt.domain.board.repository
+
+import kr.zziririt.zziririt.domain.board.model.BoardCategoryEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BoardCategoryRepository : JpaRepository<BoardCategoryEntity, Long>{
+
+    fun findByBoardId(boardId: Long) : List<BoardCategoryEntity>
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/BoardRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/BoardRepository.kt
@@ -2,7 +2,6 @@ package kr.zziririt.zziririt.domain.board.repository
 
 import kr.zziririt.zziririt.domain.board.model.BoardEntity
 import kr.zziririt.zziririt.infra.querydsl.board.BoardRowDto
-import kr.zziririt.zziririt.infra.querydsl.board.ChildBoardRowDto
 import kr.zziririt.zziririt.infra.querydsl.board.StreamerBoardRowDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -31,5 +30,4 @@ interface BoardRepository {
 
     fun findActiveStatusBoards(pageable: Pageable): Page<BoardRowDto>
 
-    fun findChildBoards(boardId: Long): List<ChildBoardRowDto>
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/BoardRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/BoardRepositoryImpl.kt
@@ -4,7 +4,6 @@ import kr.zziririt.zziririt.domain.board.model.BoardEntity
 import kr.zziririt.zziririt.infra.jpa.board.BoardJpaRepository
 import kr.zziririt.zziririt.infra.querydsl.board.BoardQueryDslRepositoryImpl
 import kr.zziririt.zziririt.infra.querydsl.board.BoardRowDto
-import kr.zziririt.zziririt.infra.querydsl.board.ChildBoardRowDto
 import kr.zziririt.zziririt.infra.querydsl.board.StreamerBoardRowDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -39,5 +38,4 @@ class BoardRepositoryImpl(
 
     override fun findActiveStatusBoards(pageable: Pageable): Page<BoardRowDto> = boardQueryDslRepositoryImpl.findActiveStatusBoards(pageable)
 
-    override fun findChildBoards(boardId: Long): List<ChildBoardRowDto> = boardQueryDslRepositoryImpl.findChildBoards(boardId)
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/CategoryRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/board/repository/CategoryRepository.kt
@@ -1,0 +1,7 @@
+package kr.zziririt.zziririt.domain.board.repository
+
+import kr.zziririt.zziririt.domain.board.model.CategoryEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CategoryRepository : JpaRepository<CategoryEntity, Long> {
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
@@ -41,7 +41,6 @@ class SocialMemberEntity(
     var defaultIcon: Long = 1L,
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
-    @Column(name = "member_icon")
     val memberIcon: MutableList<MemberIconEntity> = mutableListOf(),
 
     ) : BaseTimeEntity() {

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/BoardQueryDslRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/BoardQueryDslRepository.kt
@@ -15,5 +15,4 @@ interface BoardQueryDslRepository {
 
     fun findActiveStatusBoards(pageable: Pageable): Page<BoardRowDto>
 
-    fun findChildBoards(boardId: Long): List<ChildBoardRowDto>
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/BoardQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/BoardQueryDslRepositoryImpl.kt
@@ -20,13 +20,11 @@ class BoardQueryDslRepositoryImpl : QueryDslSupport(), BoardQueryDslRepository {
         val content = queryFactory
             .select(
                 QBoardRowDto(
-                    board.parent.id,
                     board.id,
                     board.boardName
                 )
             )
             .from(board)
-            .orderBy(board.parent.id.asc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -50,7 +48,6 @@ class BoardQueryDslRepositoryImpl : QueryDslSupport(), BoardQueryDslRepository {
             )
             .from(board)
             .where(board.boardType.eq(BoardType.STREAMER_BOARD))
-            .orderBy(board.parent.id.asc())
             .fetch()
     }
 
@@ -77,13 +74,11 @@ class BoardQueryDslRepositoryImpl : QueryDslSupport(), BoardQueryDslRepository {
         val content = queryFactory
             .select(
                 QBoardRowDto(
-                    board.parent.id,
                     board.id,
                     board.boardName
                 )
             ).from(board)
             .where(board.boardActStatus.eq(BoardActStatus.ACTIVE))
-            .orderBy(board.parent.id.asc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -95,15 +90,4 @@ class BoardQueryDslRepositoryImpl : QueryDslSupport(), BoardQueryDslRepository {
         return PageImpl(content, pageable, count)
     }
 
-    override fun findChildBoards(boardId: Long): List<ChildBoardRowDto> {
-        return queryFactory.select(
-            QChildBoardRowDto(
-                board.id,
-                board.boardName
-            )
-        ).from(board)
-            .where(board.parent.id.eq(boardId))
-            .orderBy(board.boardName.asc())
-            .fetch()
-    }
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/BoardRowDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/BoardRowDto.kt
@@ -3,7 +3,6 @@ package kr.zziririt.zziririt.infra.querydsl.board
 import com.querydsl.core.annotations.QueryProjection
 
 data class BoardRowDto @QueryProjection constructor(
-    val parentId: Long,
     val boardId: Long,
     val boardName: String
 )

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/ChildBoardRowDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/board/ChildBoardRowDto.kt
@@ -1,8 +1,0 @@
-package kr.zziririt.zziririt.infra.querydsl.board
-
-import com.querydsl.core.annotations.QueryProjection
-
-data class ChildBoardRowDto @QueryProjection constructor(
-    val boardId: Long,
-    val boardName: String
-)

--- a/src/test/kotlin/kr/zziririt/zziririt/domain/board/model/BoardEntityTest.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/domain/board/model/BoardEntityTest.kt
@@ -9,7 +9,7 @@ import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
 
 class BoardEntityTest: FeatureSpec ({
     val socialMember = SocialMemberEntity(email = "parkbro95@naver.com", nickname = "두주", provider = OAuth2Provider.NAVER, providerId = "dpUMgQQIWSw5QL3ExCfTOEPoimd239", memberRole = MemberRole.VIEWER, memberStatus = MemberStatus.NORMAL)
-    val boardFixture = BoardEntity(parent = null, socialMember = socialMember, boardName = "test boardName", boardUrl = "board Url", boardType = BoardType.ZZIRIRIT_BOARD)
+    val boardFixture = BoardEntity(socialMember = socialMember, boardName = "test boardName", boardUrl = "board Url", boardType = BoardType.ZZIRIRIT_BOARD)
 
     feature("Board Entity update 메서드를 실행한다.") {
         scenario("update 메서드를 사용하여 board 수정 시 boardName 이 수정되어야 한다.") {

--- a/src/test/kotlin/kr/zziririt/zziririt/domain/comment/model/CommentEntityTest.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/domain/comment/model/CommentEntityTest.kt
@@ -12,7 +12,7 @@ import kr.zziririt.zziririt.domain.post.model.PostEntity
 
 class CommentEntityTest: FeatureSpec({
     val socialMember = SocialMemberEntity(email = "parkbro95@naver.com", nickname = "두주", provider = OAuth2Provider.NAVER, providerId = "dpUMgQQIWSw5QL3ExCfTOEPoimd239", memberRole = MemberRole.VIEWER, memberStatus = MemberStatus.NORMAL)
-    val board = BoardEntity(parent = null, socialMember = socialMember, boardName = "보드 이름", boardUrl = "board Url", boardType = BoardType.ZZIRIRIT_BOARD)
+    val board = BoardEntity(socialMember = socialMember, boardName = "보드 이름", boardUrl = "board Url", boardType = BoardType.ZZIRIRIT_BOARD)
     val post = PostEntity(board = board, socialMember = socialMember, title = "게시글 제목", content = "게시글 내용", privateStatus = false)
     val commentFixture = CommentEntity(post = post, socialMember = socialMember, content = "댓글 내용", privateStatus = false, zziritCount = 0L)
 


### PR DESCRIPTION
### 연관 이슈
#101 


***

### 상세 개발 사항

1. ChildBoard 삭제
 - ChildBoard로 관리되던 Category들을 CategoryName으로 변경

2. Category
 - 카테고리 단건 조회
 - 카테고리 전체 조회
 - 카테고리 이름 변경
 - BoardId가 가진 카테고리 전체 조회
 - Board 생성 시 기본 카테고리 2개 제공 (공지 사항, 자유 게시판)

3. BoardEntity
 - parent (부모 게시판 삭제)