### PR TITLE
ZRR-99 Feat: Zzirit(찌릿-좋아요) 기능 API 개발

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/comment/controller/CommentController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/comment/controller/CommentController.kt
@@ -1,7 +1,7 @@
 package kr.zziririt.zziririt.api.comment.controller
 
 import jakarta.validation.Valid
-import kr.zziririt.zziririt.api.comment.dto.CommentDto
+import kr.zziririt.zziririt.api.comment.dto.CommentRequest
 import kr.zziririt.zziririt.api.comment.service.CommentService
 import kr.zziririt.zziririt.api.dto.CommonResponse
 import kr.zziririt.zziririt.global.responseEntity
@@ -19,10 +19,10 @@ class CommentController(
     @PostMapping
     fun createComment(
         @PathVariable postId: Long,
-        @Valid @RequestBody commentDto: CommentDto,
+        @Valid @RequestBody commentRequest: CommentRequest,
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<CommonResponse<Nothing>> {
-        commentService.createComment(postId, commentDto, userPrincipal)
+        commentService.createComment(postId, commentRequest, userPrincipal)
         return responseEntity(HttpStatus.CREATED)
     }
 
@@ -30,10 +30,10 @@ class CommentController(
     fun updateComment(
         @PathVariable postId: Long,
         @PathVariable commentId: Long,
-        @Valid @RequestBody commentDto: CommentDto,
+        @Valid @RequestBody commentRequest: CommentRequest,
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<CommonResponse<Nothing>> {
-        commentService.updateComment(postId, commentId, commentDto, userPrincipal)
+        commentService.updateComment(postId, commentId, commentRequest, userPrincipal)
         return responseEntity(HttpStatus.OK)
     }
 
@@ -46,11 +46,14 @@ class CommentController(
         return responseEntity(HttpStatus.NO_CONTENT)
     }
 
-    @PostMapping("/{commentId}")
-    fun incrementZzrit(
+    @PostMapping("/{commentId}/zzirit")
+    fun toggleZzirit(
+        @PathVariable commentId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ) = responseEntity(HttpStatus.OK) { commentService.toggleZzirit(commentId, userPrincipal) }
+
+    @GetMapping("/{commentId}/zzirit")
+    fun countZziritByPostId(
         @PathVariable commentId: Long
-    ): ResponseEntity<CommonResponse<Nothing>> {
-        commentService.incrementZzirit(commentId)
-        return responseEntity(HttpStatus.CREATED)
-    }
+    ) = responseEntity(HttpStatus.OK) { commentService.countZziritByCommentId(commentId) }
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/comment/dto/CommentRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/comment/dto/CommentRequest.kt
@@ -7,7 +7,7 @@ import kr.zziririt.zziririt.domain.post.model.PostEntity
 import org.springframework.validation.annotation.Validated
 
 @Validated
-data class CommentDto (
+data class CommentRequest (
     @field:Size(min = 1, max = 500, message = "댓글의 글자 수는 {min}자 이상 {max}자 이하여야 합니다.")
     val content: String,
     val privateStatus: Boolean

--- a/src/main/kotlin/kr/zziririt/zziririt/api/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/comment/dto/CommentResponse.kt
@@ -1,0 +1,25 @@
+package kr.zziririt.zziririt.api.comment.dto
+
+import kr.zziririt.zziririt.domain.comment.model.CommentEntity
+
+data class CommentResponse (
+    val memberId: Long,
+    val memberNickname: String,
+    val content: String,
+    val privateStatus: Boolean,
+    val zziritCount: Long,
+    val permissionToUpdateStatus: Boolean,
+    val permissionToDeleteStatus: Boolean
+) {
+    companion object {
+        fun from(commentEntity: CommentEntity, permissionToUpdateStatus: Boolean, permissionToDeleteStatus: Boolean) = CommentResponse(
+            memberId = commentEntity.socialMember.id!!,
+            memberNickname = commentEntity.socialMember.nickname,
+            content = commentEntity.content,
+            privateStatus = commentEntity.privateStatus,
+            zziritCount = commentEntity.zziritCount,
+            permissionToUpdateStatus = permissionToUpdateStatus,
+            permissionToDeleteStatus = permissionToDeleteStatus
+        )
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/comment/service/CommentService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/comment/service/CommentService.kt
@@ -1,35 +1,42 @@
 package kr.zziririt.zziririt.api.comment.service
 
-import kr.zziririt.zziririt.api.comment.dto.CommentDto
+import kr.zziririt.zziririt.api.comment.dto.CommentRequest
+import kr.zziririt.zziririt.api.comment.dto.CommentResponse
+import kr.zziririt.zziririt.api.post.dto.response.ZziritStatusResponse
 import kr.zziririt.zziririt.domain.comment.repository.CommentRepository
+import kr.zziririt.zziririt.domain.member.model.MemberRole
 import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
 import kr.zziririt.zziririt.domain.post.repository.PostRepository
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntityType
+import kr.zziririt.zziririt.domain.zzirit.repository.ZziritRepository
 import kr.zziririt.zziririt.global.exception.ErrorCode
 import kr.zziririt.zziririt.global.exception.ModelNotFoundException
 import kr.zziririt.zziririt.infra.security.UserPrincipal
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CommentService(
     private val postRepository: PostRepository,
     private val socialMemberRepository: SocialMemberRepository,
-    private val commentRepository: CommentRepository
+    private val commentRepository: CommentRepository,
+    private val zziritRepository: ZziritRepository
 ) {
-    fun createComment(postId: Long, commentDto: CommentDto, userPrincipal: UserPrincipal) {
+    fun createComment(postId: Long, commentRequest: CommentRequest, userPrincipal: UserPrincipal) {
         val findSocialMember =
             socialMemberRepository.findByIdOrNull(userPrincipal.memberId) ?: throw ModelNotFoundException(
                 ErrorCode.MODEL_NOT_FOUND
             )
         val findPost = postRepository.findByIdOrNull(postId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
-        val saveComment = commentDto.to(findSocialMember, findPost)
+        val saveComment = commentRequest.to(findSocialMember, findPost)
 
         commentRepository.save(saveComment)
     }
 
     @Transactional
-    fun updateComment(postId: Long, commentId: Long, commentDto: CommentDto, userPrincipal: UserPrincipal) {
+    fun updateComment(postId: Long, commentId: Long, commentRequest: CommentRequest, userPrincipal: UserPrincipal) {
         socialMemberRepository.findByIdOrNull(userPrincipal.memberId) ?: throw ModelNotFoundException(
             ErrorCode.MODEL_NOT_FOUND
         )
@@ -37,10 +44,10 @@ class CommentService(
         val findComment =
             commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
 
-        if (commentDto.privateStatus != findComment.privateStatus) {
+        if (commentRequest.privateStatus != findComment.privateStatus) {
             findComment.togglePrivateStatus()
         }
-        findComment.update(content = commentDto.content)
+        findComment.update(content = commentRequest.content)
     }
 
     fun deleteComment(commentId: Long, userPrincipal: UserPrincipal) {
@@ -52,11 +59,60 @@ class CommentService(
         commentRepository.delete(findComment)
     }
 
-    @Transactional
-    fun incrementZzirit(commentId: Long) {
+    fun getComments(userPrincipal: UserPrincipal?, postId: Long): List<CommentResponse>? {
+        val findComments = commentRepository.findAllByPostId(postId)
+
+        return if (userPrincipal != null) {
+            val findSocialMember = socialMemberRepository.findByIdOrNull(userPrincipal.memberId)
+                ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+            findComments?.map {
+                var permissionToUpdateStatus = false
+                var permissionToDeleteStatus = false
+                if (it.socialMember.id == userPrincipal.memberId) {
+                    permissionToUpdateStatus = true
+                    permissionToDeleteStatus = true
+                } else if (findSocialMember.memberRole == MemberRole.ADMIN || userPrincipal.memberId == it.post.board.id) {
+                    permissionToDeleteStatus = true
+                }
+                CommentResponse.from(it, permissionToUpdateStatus, permissionToDeleteStatus)
+            }
+        } else findComments?.map { CommentResponse.from(it, false, false) }
+    }
+
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun toggleZzirit(commentId: Long, userPrincipal: UserPrincipal): ZziritStatusResponse {
         val findComment =
             commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+        var findZzirit = zziritRepository.findZziritByMemberIdAndCommentIdOrNull(userPrincipal.memberId, commentId)
 
-        findComment.incrementZzirit()
+        if (findZzirit == null) {
+            val findSocialMember = socialMemberRepository.findByIdOrNull(userPrincipal.memberId)
+                ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+            findComment.incrementZzirit()
+
+            return ZziritStatusResponse.of(
+                zziritRepository.save(
+                    ZziritEntity(
+                        socialMember = findSocialMember,
+                        entityId = commentId,
+                        zziritEntityType = ZziritEntityType.COMMENT
+                    )
+                )
+            )
+        }
+
+
+        if (findZzirit.toggleZzirit()) {
+            findComment.incrementZzirit()
+        } else {
+            findComment.decrementZzirit()
+        }
+
+        return ZziritStatusResponse.of(findZzirit)
     }
+
+    @Transactional(readOnly = true)
+    fun countZziritByCommentId(commentId: Long) = zziritRepository.countZziritByCommentId(commentId)
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/post/controller/PostController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/post/controller/PostController.kt
@@ -89,4 +89,15 @@ class PostController(
         postService.deletePost(postId, userPrincipal)
         return responseEntity(HttpStatus.NO_CONTENT)
     }
+
+    @PostMapping("/v1/boards/{boardId}/posts/{postId}/zzirit")
+    fun toggleZzirit(
+        @PathVariable postId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ) = responseEntity(HttpStatus.OK) { postService.toggleZzirit(postId, userPrincipal) }
+
+    @GetMapping("/v1/boards/{boardId}/posts/{postId}/zzirit")
+    fun countZziritByPostId(
+        @PathVariable postId: Long
+    ) = responseEntity(HttpStatus.OK) { postService.countZziritByPostId(postId) }
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/post/dto/response/PostResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/post/dto/response/PostResponse.kt
@@ -1,8 +1,8 @@
 package kr.zziririt.zziririt.api.post.dto.response
 
+import kr.zziririt.zziririt.api.comment.dto.CommentResponse
 import kr.zziririt.zziririt.domain.post.model.PostEntity
 import java.time.LocalDateTime
-
 
 data class PostResponse(
     val postId: Long,
@@ -20,10 +20,16 @@ data class PostResponse(
     val permissionToDeleteStatus: Boolean,
     val zziritCount: Long,
     val hit: Long,
+    val commentResponses: List<CommentResponse>?,
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun of(postEntity: PostEntity, permissionToUpdateStatus: Boolean, permissionToDeleteStatus: Boolean): PostResponse = PostResponse(
+        fun of(
+            postEntity: PostEntity,
+            permissionToUpdateStatus: Boolean,
+            permissionToDeleteStatus: Boolean,
+            comments: List<CommentResponse>?
+        ): PostResponse = PostResponse(
             postId = postEntity.id!!,
             title = postEntity.title,
             content = postEntity.content,
@@ -39,6 +45,7 @@ data class PostResponse(
             permissionToDeleteStatus = permissionToDeleteStatus,
             zziritCount = postEntity.zziritCount,
             hit = postEntity.hit,
+            commentResponses = comments,
             createdAt = postEntity.createdAt
         )
     }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/post/dto/response/ZziritStatusResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/post/dto/response/ZziritStatusResponse.kt
@@ -1,0 +1,20 @@
+package kr.zziririt.zziririt.api.post.dto.response
+
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntityType
+
+data class ZziritStatusResponse(
+    val zziritToEntityId: Long,
+    val zziritEntityType: ZziritEntityType,
+    val zziritFromMemberId: Long,
+    val isZzirit: Boolean
+) {
+    companion object {
+        fun of(zziritEntity: ZziritEntity) = ZziritStatusResponse(
+            zziritToEntityId = zziritEntity.entityId,
+            zziritEntityType = zziritEntity.zziritEntityType,
+            zziritFromMemberId = zziritEntity.socialMember.id!!,
+            isZzirit = zziritEntity.isZzirit
+        )
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/comment/model/CommentEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/comment/model/CommentEntity.kt
@@ -40,6 +40,8 @@ class CommentEntity(
 
     fun incrementZzirit() = this.zziritCount++
 
+    fun decrementZzirit() = this.zziritCount--
+
     fun togglePrivateStatus() {
         this.privateStatus = !privateStatus
     }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/comment/repository/CommentRepository.kt
@@ -1,9 +1,10 @@
 package kr.zziririt.zziririt.domain.comment.repository
 
 import kr.zziririt.zziririt.domain.comment.model.CommentEntity
-import org.springframework.data.repository.CrudRepository
-import org.springframework.stereotype.Repository
 
-@Repository
-interface CommentRepository : CrudRepository<CommentEntity, Long> {
+interface CommentRepository {
+    fun save(commentEntity: CommentEntity): CommentEntity
+    fun delete(commentEntity: CommentEntity)
+    fun findByIdOrNull(commentId: Long): CommentEntity?
+    fun findAllByPostId(postId: Long): List<CommentEntity>?
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/comment/repository/CommentRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/comment/repository/CommentRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package kr.zziririt.zziririt.domain.comment.repository
+
+import kr.zziririt.zziririt.domain.comment.model.CommentEntity
+import kr.zziririt.zziririt.infra.jpa.comment.CommentJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class CommentRepositoryImpl(
+    private val commentJpaRepository: CommentJpaRepository
+):CommentRepository {
+    override fun save(commentEntity: CommentEntity): CommentEntity = commentJpaRepository.save(commentEntity)
+    override fun delete(commentEntity: CommentEntity) = commentJpaRepository.delete(commentEntity)
+    override fun findByIdOrNull(commentId: Long): CommentEntity? = commentJpaRepository.findByIdOrNull(commentId)
+    override fun findAllByPostId(postId: Long): List<CommentEntity>? =
+        commentJpaRepository.findAllByPostIdAndPrivateStatus(postId, false)
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntity.kt
@@ -55,6 +55,8 @@ class PostEntity(
 
     fun incrementZzirit() = this.zziritCount++
 
+    fun decrementZzirit() = this.zziritCount--
+
     fun incrementHit() = this.hit++
 
     fun togglePrivateStatus() {

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/model/ZziritEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/model/ZziritEntity.kt
@@ -1,0 +1,38 @@
+package kr.zziririt.zziririt.domain.zzirit.model
+
+import jakarta.persistence.*
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.domain.post.model.PostEntity
+import kr.zziririt.zziririt.global.entity.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "zzirit")
+@SQLDelete(sql = "UPDATE zzirit SET is_deleted = true WHERE id = ?")
+@SQLRestriction(value = "is_deleted = false")
+class ZziritEntity(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member")
+    val socialMember: SocialMemberEntity,
+
+    @Column(name = "entity_id")
+    val entityId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entity_type")
+    var zziritEntityType: ZziritEntityType,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    @Column(name = "isZzirit", nullable = false)
+    var isZzirit: Boolean = true
+
+    fun toggleZzirit(): Boolean {
+        isZzirit = !isZzirit
+        return isZzirit
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/model/ZziritEntityType.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/model/ZziritEntityType.kt
@@ -1,0 +1,5 @@
+package kr.zziririt.zziririt.domain.zzirit.model
+
+enum class ZziritEntityType {
+    POST, COMMENT
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepository.kt
@@ -1,0 +1,11 @@
+package kr.zziririt.zziririt.domain.zzirit.repository
+
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
+
+interface ZziritRepository {
+    fun save(entity: ZziritEntity): ZziritEntity
+    fun findZziritByMemberIdAndPostIdOrNull(socialMemberId: Long, postId: Long): ZziritEntity?
+    fun findZziritByMemberIdAndCommentIdOrNull(socialMemberId: Long, commentId: Long): ZziritEntity?
+    fun countZziritByPostId(postId: Long): Long
+    fun countZziritByCommentId(commentId: Long): Long
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package kr.zziririt.zziririt.domain.zzirit.repository
+
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntityType
+import kr.zziririt.zziririt.infra.jpa.zzirit.ZziritJpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ZziritRepositoryImpl(
+    private val zziritJpaRepository: ZziritJpaRepository
+) : ZziritRepository {
+    override fun save(entity: ZziritEntity): ZziritEntity = zziritJpaRepository.save(entity)
+    override fun findZziritByMemberIdAndPostIdOrNull(
+        socialMemberId: Long,
+        postId: Long
+    ): ZziritEntity? =
+        zziritJpaRepository.findBySocialMemberIdAndEntityIdAndZziritEntityType(socialMemberId, postId, ZziritEntityType.POST)
+
+    override fun findZziritByMemberIdAndCommentIdOrNull(
+        socialMemberId: Long,
+        commentId: Long
+    ): ZziritEntity? =
+        zziritJpaRepository.findBySocialMemberIdAndEntityIdAndZziritEntityType(socialMemberId, commentId, ZziritEntityType.COMMENT)
+
+    override fun countZziritByPostId(postId: Long): Long =
+        zziritJpaRepository.countByIsZziritAndEntityIdAndZziritEntityTypeAndIsDeleted(
+            true,
+            postId,
+            ZziritEntityType.POST,
+            false
+        )
+
+    override fun countZziritByCommentId(commentId: Long): Long =
+        zziritJpaRepository.countByIsZziritAndEntityIdAndZziritEntityTypeAndIsDeleted(
+            true,
+            commentId,
+            ZziritEntityType.COMMENT,
+            false
+        )
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/comment/CommentJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/comment/CommentJpaRepository.kt
@@ -1,0 +1,8 @@
+package kr.zziririt.zziririt.infra.jpa.comment
+
+import kr.zziririt.zziririt.domain.comment.model.CommentEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentJpaRepository : JpaRepository<CommentEntity, Long> {
+    fun findAllByPostIdAndPrivateStatus(postId: Long, privateStatus: Boolean): List<CommentEntity>?
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/zzirit/ZziritJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/zzirit/ZziritJpaRepository.kt
@@ -1,0 +1,10 @@
+package kr.zziririt.zziririt.infra.jpa.zzirit
+
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntityType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ZziritJpaRepository: JpaRepository<ZziritEntity, Long> {
+    fun findBySocialMemberIdAndEntityIdAndZziritEntityType(socialMemberId: Long, entityId: Long, entityType: ZziritEntityType): ZziritEntity?
+    fun countByIsZziritAndEntityIdAndZziritEntityTypeAndIsDeleted(isZzirit: Boolean, entityId: Long, entityType: ZziritEntityType, isDeleted: Boolean): Long
+}


### PR DESCRIPTION
# 관련 이슈
closes #105 

---
# 개발 내용
- ZziritEntity: 
    - 찌릿 엔티티 작성
- ZziritEntityType: 
    - 찌릿 대상 엔티티 Enum 타입 추가
- ZziritRepository: 
    - 찌릿을 위한 Repository interface 작성
- ZziritRepositoryImpl: 
    - 찌릿을 위한 Repository 구현체 작성
- ZziritJpaRepository: 
    - 찌릿을 위한 JpaRepository interface 작성
- ZziritStatusResponse: 
    - 좋아요 상태 응답 Dto 작성
- PostService: 
    - 찌릿 로직 추가
- PostResponse: 
    - 댓글 추가
- PostEntity: 
    - 찌리릿 감소 메소드 추가
- PostController: 
    - 게시글 찌릿 토글 기능 추가 
    - 찌릿 갯수 조회 추가
- CommentController: 
    - 댓글 찌릿 토글 기능 추가 
    - 찌릿 갯수 조회 추가
- CommentService: 
    - 댓글 찌릿 토글 기능 추가 
    - 찌릿 갯수 조회 추가 
    - 댓글 조회 기능 추가
- CommentEntity: 
    - 찌릿 감소 메소드 추가
- CommentRequest: 
    - CommentDto -> CommentRequest
- CommentResponse: 
    - 댓글 반환을 위한 CommentResponse DTO 작성
- CommentRequest: 
    - CommentDto -> CommentRequest
- CommentRepository: 
    - 저장, 삭제, 조회 기능 추가
- CommentRepositoryImpl: 
    - 저장, 삭제 기능 구현체 작성
- CommentJpaRepository: 
    - 조회 기능 구현