### PR TITLE
ZRR-105 Fix: Post And Comment API 버그 수정

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/comment/dto/CommentResponse.kt
@@ -3,6 +3,7 @@ package kr.zziririt.zziririt.api.comment.dto
 import kr.zziririt.zziririt.domain.comment.model.CommentEntity
 
 data class CommentResponse (
+    val commentId: Long,
     val memberId: Long,
     val memberNickname: String,
     val content: String,
@@ -13,6 +14,7 @@ data class CommentResponse (
 ) {
     companion object {
         fun from(commentEntity: CommentEntity, permissionToUpdateStatus: Boolean, permissionToDeleteStatus: Boolean) = CommentResponse(
+            commentId = commentEntity.id!!,
             memberId = commentEntity.socialMember.id!!,
             memberNickname = commentEntity.socialMember.nickname,
             content = commentEntity.content,

--- a/src/main/kotlin/kr/zziririt/zziririt/api/post/dto/response/PostResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/post/dto/response/PostResponse.kt
@@ -19,6 +19,7 @@ data class PostResponse(
     val permissionToUpdateStatus: Boolean,
     val permissionToDeleteStatus: Boolean,
     val zziritCount: Long,
+    val isZzirit: Boolean,
     val hit: Long,
     val commentResponses: List<CommentResponse>?,
     val createdAt: LocalDateTime,
@@ -28,7 +29,8 @@ data class PostResponse(
             postEntity: PostEntity,
             permissionToUpdateStatus: Boolean,
             permissionToDeleteStatus: Boolean,
-            comments: List<CommentResponse>?
+            comments: List<CommentResponse>?,
+            isZzirit: Boolean
         ): PostResponse = PostResponse(
             postId = postEntity.id!!,
             title = postEntity.title,
@@ -44,6 +46,7 @@ data class PostResponse(
             permissionToUpdateStatus = permissionToUpdateStatus,
             permissionToDeleteStatus = permissionToDeleteStatus,
             zziritCount = postEntity.zziritCount,
+            isZzirit = isZzirit,
             hit = postEntity.hit,
             commentResponses = comments,
             createdAt = postEntity.createdAt

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/comment/repository/CommentRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/comment/repository/CommentRepositoryImpl.kt
@@ -13,5 +13,5 @@ class CommentRepositoryImpl(
     override fun delete(commentEntity: CommentEntity) = commentJpaRepository.delete(commentEntity)
     override fun findByIdOrNull(commentId: Long): CommentEntity? = commentJpaRepository.findByIdOrNull(commentId)
     override fun findAllByPostId(postId: Long): List<CommentEntity>? =
-        commentJpaRepository.findAllByPostIdAndPrivateStatus(postId, false)
+        commentJpaRepository.findAllByPostId(postId)
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/comment/CommentJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/comment/CommentJpaRepository.kt
@@ -4,5 +4,5 @@ import kr.zziririt.zziririt.domain.comment.model.CommentEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CommentJpaRepository : JpaRepository<CommentEntity, Long> {
-    fun findAllByPostIdAndPrivateStatus(postId: Long, privateStatus: Boolean): List<CommentEntity>?
+    fun findAllByPostId(postId: Long): List<CommentEntity>?
 }


### PR DESCRIPTION
# 관련이슈
Closes #122

---

#개선사항
1. getPost API dto 수정 - isZzirit 좋아요 상태 여부를 추가
2. Comment Api 반환 dto 인자 추가 - commentId가 누락되어 추가
3. Comment - findAllByPostId 수정 - 기존에는 비밀글이 조회되지 않았던 로직을 비밀글도 조회할 수 있도록 수정