### PR TITLE
ZRR-113 Feat: Popular Posts(TOP5)

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/controller/ZziritController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/controller/ZziritController.kt
@@ -1,0 +1,21 @@
+package kr.zziririt.zziririt.api.zzirit.controller
+
+import kr.zziririt.zziririt.api.zzirit.service.ZziritService
+import kr.zziririt.zziririt.global.responseEntity
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/zzirits")
+class ZziritController (
+    private val zziritService: ZziritService
+){
+
+    @GetMapping("/rankings")
+    fun getZziritRanking() = responseEntity(HttpStatus.OK) {
+        zziritService.findZziritRanking()
+    }
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/dto/response/ZziritCountResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/dto/response/ZziritCountResponse.kt
@@ -5,4 +5,5 @@ data class ZziritCountResponse(
     val zziritCount: Long,
     val postTitle: String,
     val boardUrl: String,
+    val boardId: Long,
 )

--- a/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/dto/response/ZziritCountResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/dto/response/ZziritCountResponse.kt
@@ -1,0 +1,8 @@
+package kr.zziririt.zziririt.api.zzirit.dto.response
+
+data class ZziritCountResponse(
+    val postId: Long,
+    val zziritCount: Long,
+    val postTitle: String,
+    val boardUrl: String,
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/service/ZziritService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/zzirit/service/ZziritService.kt
@@ -1,0 +1,33 @@
+package kr.zziririt.zziririt.api.zzirit.service
+
+import kr.zziririt.zziririt.api.zzirit.dto.response.ZziritCountResponse
+import kr.zziririt.zziririt.domain.zzirit.repository.ZziritRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ZziritService (
+    private val zziritRepository: ZziritRepository
+) {
+    @Scheduled(cron = "0 0 0/1 1/1 * ?")
+    fun updateRank(){
+        val range = LocalDateTime.now().minusDays(1)
+        val ranking = zziritRepository.findZziritRankInPosts(range)
+        zziritRepository.updateRank(ranking)
+    }
+
+    fun findZziritRanking() : List<ZziritCountResponse>? {
+
+        var rankingInRedis = zziritRepository.findZziritPostRankingInRedis()
+
+        if(rankingInRedis==null || rankingInRedis.isEmpty()) {
+            val range = LocalDateTime.now().minusDays(1)
+            val ranking = zziritRepository.findZziritRankInPosts(range)
+            zziritRepository.updateRank(ranking)
+            rankingInRedis = zziritRepository.findZziritPostRankingInRedis()
+        }
+
+        return rankingInRedis
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepository.kt
@@ -1,6 +1,9 @@
 package kr.zziririt.zziririt.domain.zzirit.repository
 
+import kr.zziririt.zziririt.api.zzirit.dto.response.ZziritCountResponse
 import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
+import kr.zziririt.zziririt.infra.querydsl.zzirit.dto.ZziritDto
+import java.time.LocalDateTime
 
 interface ZziritRepository {
     fun save(entity: ZziritEntity): ZziritEntity
@@ -8,4 +11,7 @@ interface ZziritRepository {
     fun findZziritByMemberIdAndCommentIdOrNull(socialMemberId: Long, commentId: Long): ZziritEntity?
     fun countZziritByPostId(postId: Long): Long
     fun countZziritByCommentId(commentId: Long): Long
+    fun findZziritRankInPosts(range: LocalDateTime): List<ZziritDto>
+    fun updateRank(zziritRank: List<ZziritDto>)
+    fun findZziritPostRankingInRedis() : List<ZziritCountResponse>?
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/zzirit/repository/ZziritRepositoryImpl.kt
@@ -1,13 +1,20 @@
 package kr.zziririt.zziririt.domain.zzirit.repository
 
+import kr.zziririt.zziririt.api.zzirit.dto.response.ZziritCountResponse
 import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntity
 import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntityType
 import kr.zziririt.zziririt.infra.jpa.zzirit.ZziritJpaRepository
+import kr.zziririt.zziririt.infra.querydsl.zzirit.ZziritQueryDslRepository
+import kr.zziririt.zziririt.infra.querydsl.zzirit.dto.ZziritDto
+import kr.zziririt.zziririt.infra.redis.zzirit.ZziritRedisRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class ZziritRepositoryImpl(
-    private val zziritJpaRepository: ZziritJpaRepository
+    private val zziritJpaRepository: ZziritJpaRepository,
+    private val zziritQueryDslRepository: ZziritQueryDslRepository,
+    private val zziritRedisRepository: ZziritRedisRepository
 ) : ZziritRepository {
     override fun save(entity: ZziritEntity): ZziritEntity = zziritJpaRepository.save(entity)
     override fun findZziritByMemberIdAndPostIdOrNull(
@@ -37,4 +44,13 @@ class ZziritRepositoryImpl(
             ZziritEntityType.COMMENT,
             false
         )
+
+    override fun findZziritRankInPosts(range: LocalDateTime): List<ZziritDto> =
+        zziritQueryDslRepository.findZziritRankInPosts(range)
+
+    override fun updateRank(zziritRank: List<ZziritDto>) =
+        zziritRedisRepository.updateRank(zziritRank)
+
+    override fun findZziritPostRankingInRedis(): List<ZziritCountResponse>? =
+        zziritRedisRepository.findZziritPostRankingInRedis()
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/ZziritQueryDslRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/ZziritQueryDslRepository.kt
@@ -1,0 +1,10 @@
+package kr.zziririt.zziririt.infra.querydsl.zzirit
+
+import kr.zziririt.zziririt.infra.querydsl.zzirit.dto.ZziritDto
+import java.time.LocalDateTime
+
+interface ZziritQueryDslRepository {
+
+    fun findZziritRankInPosts(range: LocalDateTime): List<ZziritDto>
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/ZziritQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/ZziritQueryDslRepositoryImpl.kt
@@ -25,7 +25,8 @@ class ZziritQueryDslRepositoryImpl(
                 zzirit.entityId,
                 post.zziritCount,
                 post.title,
-                post.board.boardUrl
+                post.board.boardUrl,
+                post.board.id
             ))
             .from(zzirit)
             .leftJoin(post)

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/ZziritQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/ZziritQueryDslRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package kr.zziririt.zziririt.infra.querydsl.zzirit
+
+import kr.zziririt.zziririt.domain.board.model.QBoardEntity
+import kr.zziririt.zziririt.domain.post.model.QPostEntity
+import kr.zziririt.zziririt.domain.zzirit.model.QZziritEntity
+import kr.zziririt.zziririt.domain.zzirit.model.ZziritEntityType
+import kr.zziririt.zziririt.infra.querydsl.QueryDslSupport
+import kr.zziririt.zziririt.infra.querydsl.zzirit.dto.QZziritDto
+import kr.zziririt.zziririt.infra.querydsl.zzirit.dto.ZziritDto
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class ZziritQueryDslRepositoryImpl(
+
+) : QueryDslSupport(), ZziritQueryDslRepository {
+    override fun findZziritRankInPosts(range: LocalDateTime): List<ZziritDto> {
+        val zzirit = QZziritEntity.zziritEntity
+        val post = QPostEntity.postEntity
+        val board = QBoardEntity.boardEntity
+        val limitCount = 5L
+
+        val result = queryFactory
+            .select(QZziritDto(
+                zzirit.entityId,
+                post.zziritCount,
+                post.title,
+                post.board.boardUrl
+            ))
+            .from(zzirit)
+            .leftJoin(post)
+            .on(zzirit.entityId.eq(post.id)).fetchJoin()
+            .leftJoin(board)
+            .on(post.board.eq(board)).fetchJoin()
+            .where(zzirit.zziritEntityType.eq(ZziritEntityType.POST))
+            .where(zzirit.isDeleted.eq(false))
+            .where(zzirit.createdAt.after(range))
+            .orderBy(post.zziritCount.desc())
+            .limit(limitCount)
+            .fetch()
+
+        return result
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/dto/ZziritDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/dto/ZziritDto.kt
@@ -1,0 +1,10 @@
+package kr.zziririt.zziririt.infra.querydsl.zzirit.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class ZziritDto @QueryProjection constructor(
+    val postId: Long,
+    val zziritCount: Long,
+    val postTitle: String,
+    val boardUrl: String,
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/dto/ZziritDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/zzirit/dto/ZziritDto.kt
@@ -7,4 +7,5 @@ data class ZziritDto @QueryProjection constructor(
     val zziritCount: Long,
     val postTitle: String,
     val boardUrl: String,
+    val boardId: Long,
 )

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/redis/zzirit/ZziritRedisRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/redis/zzirit/ZziritRedisRepository.kt
@@ -1,0 +1,49 @@
+package kr.zziririt.zziririt.infra.redis.zzirit
+
+import kr.zziririt.zziririt.api.zzirit.dto.response.ZziritCountResponse
+import kr.zziririt.zziririt.infra.querydsl.zzirit.dto.ZziritDto
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class ZziritRedisRepository(
+    private val redisTemplate: RedisTemplate<String, String>
+) {
+    val key = "postzzirit:ranking"
+    fun updateRank(zziritRank: List<ZziritDto>) {
+
+        redisTemplate.delete(key)
+        //key, value 값으로 묶어 줌 (postId와 zziritCount)
+        val rankHash = zziritRank.associate { it.postId.toString() to it.zziritCount }
+        redisTemplate.opsForHash<String, Long>().putAll(key, rankHash)
+
+        zziritRank.forEach {
+            val infoKey = "zziritInfo:${it.postId}"
+            redisTemplate.opsForHash<String, String>().putAll(
+                infoKey, mapOf(
+                    "postId" to it.postId.toString(),
+                    "postTitle" to it.postTitle,
+                    "boardUrl" to it.boardUrl,
+                    "zziritCount" to it.zziritCount.toString()
+                )
+            )
+        }
+    }
+
+    fun findZziritPostRankingInRedis(): List<ZziritCountResponse>? {
+        val rankings = redisTemplate.opsForHash<String, Long>().entries(key)
+            ?: return emptyList()
+
+        return rankings.map { (postId, zziritCount) ->
+            val infoKey = "zziritInfo:$postId"
+            val details = redisTemplate.opsForHash<String, String>().entries(infoKey)
+
+            ZziritCountResponse(
+                postId = details["postId"]?.toLong() ?: 0L,
+                zziritCount = details["zziritCount"]?.toLong() ?: 0L,
+                postTitle = details["postTitle"] ?: "",
+                boardUrl = details["boardUrl"] ?: "",
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/redis/zzirit/ZziritRedisRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/redis/zzirit/ZziritRedisRepository.kt
@@ -13,7 +13,7 @@ class ZziritRedisRepository(
     fun updateRank(zziritRank: List<ZziritDto>) {
 
         redisTemplate.delete(key)
-        //key, value 값으로 묶어 줌 (postId와 zziritCount)
+        //key, value 값으로 묶어 줍니다. (postId와 zziritCount)
         val rankHash = zziritRank.associate { it.postId.toString() to it.zziritCount }
         redisTemplate.opsForHash<String, Long>().putAll(key, rankHash)
 
@@ -24,7 +24,8 @@ class ZziritRedisRepository(
                     "postId" to it.postId.toString(),
                     "postTitle" to it.postTitle,
                     "boardUrl" to it.boardUrl,
-                    "zziritCount" to it.zziritCount.toString()
+                    "zziritCount" to it.zziritCount.toString(),
+                    "boardId" to it.boardId.toString()
                 )
             )
         }
@@ -43,6 +44,7 @@ class ZziritRedisRepository(
                 zziritCount = details["zziritCount"]?.toLong() ?: 0L,
                 postTitle = details["postTitle"] ?: "",
                 boardUrl = details["boardUrl"] ?: "",
+                boardId = details["boardId"]?.toLong() ?: 0L,
             )
         }
     }


### PR DESCRIPTION
### 연관 티켓
#144 

***

### 상세 내용

1. zziritController
- 24시간 내 가장 많은 찌릿을 받은 상위 5개의 Post를 가져올 수 있음
2. ZziritCountResponse
- 반환정보: postId, zziritCount, postTitle, boardUrl
3. QueryDSL
- 최근 24시간 내 작성된 게시글 중 zzirit Count가 높은 순서대로 게시글을 n개 출력함
- 5개로 설정되어 있으나, 10개로 변경 할 경우 limitCount 수정
4. ZziritService
- 1시간 간격으로 rank를 update함 (00시 기준 24시간이 아니라 현재 시각 기준 24시간으로 설정하기 위함)
- redis 문제 등으로 인해 cache가 없는 경우 다시 update를 진행하여 값을 생성함